### PR TITLE
Modify ramp colors correspond to days in a week, in a rainbow order

### DIFF
--- a/frontend/src/components/c-ramp.vue
+++ b/frontend/src/components/c-ramp.vue
@@ -228,7 +228,7 @@ export default defineComponent({
           ? (new Date(this.sdate)).getTime()
           : (new Date(slice.date)).getTime();
 
-      return (timeMs / window.DAY_IN_MS) % 5;
+      return (timeMs / window.DAY_IN_MS) % 7;
     },
 
     // Prevent browser from switching to new tab when clicking ramp
@@ -272,23 +272,31 @@ export default defineComponent({
     width: 0;
 
     &--color0 {
-      border-bottom: $height rgba(mui-color('orange'), .5) solid;
-    }
-
-    &--color1 {
-      border-bottom: $height rgba(mui-color('light-blue'), .5) solid;
-    }
-
-    &--color2 {
       border-bottom: $height rgba(mui-color('green'), .5) solid;
     }
 
-    &--color3 {
+    &--color1 {
+      border-bottom: $height rgba(mui-color('blue'), .5) solid;
+    }
+
+    &--color2 {
       border-bottom: $height rgba(mui-color('indigo'), .5) solid;
     }
 
+    &--color3 {
+      border-bottom: $height rgba(mui-color('purple'), .5) solid;
+    }
+
     &--color4 {
-      border-bottom: $height rgba(mui-color('pink'), .5) solid;
+      border-bottom: $height rgba(mui-color('brown'), .5) solid;
+    }
+
+    &--color5 {
+      border-bottom: $height rgba(mui-color('orange'), .5) solid;
+    }
+
+    &--color6 {
+      border-bottom: $height rgba(mui-color('lime'), .5) solid;
     }
 
     &--color-deletes {


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Part of #2216

### Explanation
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

The color in a ramp indicates the day in which a commit is done, in a 5-day cycle. Currently, the colors do not have much meaning beyond telling the user that the commits are done within a day. Furthermore, one of the colors used, pink, was too similar to red, the color reserved for delete commits. Thus, this PR is made to address these issues.

Each color now corresponds to each day in a week (i.e. the 5-day cycle is replaced by 7-day cycle). To make the colors easy to remember, they follow the rainbow colors, but with red being replaced with brown (as red is reserved for delete commits), and yellow being replaced with lime (to increase contrast against the bright background). Monday (first day in a working week) corresponds to the first color. These colors are all distinct from red, hence allowing the user to easily distinguish between delete commits and other commits.

### Screenshot
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
![image](https://github.com/logical-1985516/RepoSense/assets/107944536/8876a704-092f-4705-bb78-c2a2edc8e219)
