### PR TITLE
Change all ramp colors to orange

### DIFF
--- a/frontend/src/components/c-ramp.vue
+++ b/frontend/src/components/c-ramp.vue
@@ -224,11 +224,7 @@ export default defineComponent({
       if (this.isDeletesContribution(slice)) {
         return '-deletes';
       }
-      const timeMs = this.fromramp
-          ? (new Date(this.sdate)).getTime()
-          : (new Date(slice.date)).getTime();
-
-      return (timeMs / window.DAY_IN_MS) % 5;
+      return 0;
     },
 
     // Prevent browser from switching to new tab when clicking ramp


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2216

### Explanation
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

The color in a ramp indicates the day in which a commit is done, in a 5-day cycle. As quoted from issue #2216,

> To a viewer, this may to confusing. For example, the viewer might think the color of the ramp indicates the file types that were modified in that commit.
> 
> The color in the ramp is currently used to indicate the day the commit was done, so that it is easy to see which commits were done on a specific day, across repos. Personally, I don't think this feature adds much value.
> 
> So, one option is to use the same color for ramps so that it is clear the colors are used to indicate file type breakdown only.

This PR changes the colors in the ramp to only orange. The screenshot below shows the change.

### Screenshot
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
![image](https://github.com/logical-1985516/RepoSense/assets/107944536/8b1724c0-3d79-47b4-97e7-b033c2b2dc2d)